### PR TITLE
Allow client tools to omit responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ val config = ConversationConfig(
     // List of client tools the agent can invoke
     clientTools = mapOf(
         "logMessage" to object : ClientTool {
-            override suspend fun execute(parameters: Map<String, Any>): ClientToolResult {
+            override suspend fun execute(parameters: Map<String, Any>): ClientToolResult? {
                 val message = parameters["message"] as? String
 
                 Log.d("ExampleApp", "[INFO] Client Tool Log: $message")
@@ -113,6 +113,8 @@ val config = ConversationConfig(
         }
     ),
 )
+
+> **Note:** If a tool is configured with `expects_response=false` on the server, return `null` or `ClientToolResult.noResponse()` from `execute` to skip sending a tool result.
 
 // In an Activity context
 val session: ConversationSession = ConversationClient.startSession(config, this)
@@ -165,7 +167,7 @@ val config = ConversationConfig(
     agentId = "<public_agent>",
     clientTools = mapOf(
         "logMessage" to object : io.elevenlabs.ClientTool {
-            override suspend fun execute(parameters: Map<String, Any>): io.elevenlabs.ClientToolResult {
+            override suspend fun execute(parameters: Map<String, Any>): io.elevenlabs.ClientToolResult? {
                 val message = parameters["message"] as? String ?: return io.elevenlabs.ClientToolResult.failure("Missing 'message'")
                 android.util.Log.d("ClientTool", "Log: $message")
                 return io.elevenlabs.ClientToolResult.success("ok")

--- a/elevenlabs-sdk/src/main/java/io/elevenlabs/ClientTool.kt
+++ b/elevenlabs-sdk/src/main/java/io/elevenlabs/ClientTool.kt
@@ -11,9 +11,9 @@ interface ClientTool {
      * Execute the tool with the provided parameters
      *
      * @param parameters Map of parameter names to values provided by the agent
-     * @return Result of the tool execution
+     * @return Result of the tool execution or null to indicate no response should be sent
      */
-    suspend fun execute(parameters: Map<String, Any>): ClientToolResult
+    suspend fun execute(parameters: Map<String, Any>): ClientToolResult?
 }
 
 /**
@@ -45,5 +45,10 @@ data class ClientToolResult(
             result = "",
             error = error
         )
+
+        /**
+         * Special helper to indicate no response should be sent
+         */
+        fun noResponse(): ClientToolResult? = null
     }
 }

--- a/elevenlabs-sdk/src/main/java/io/elevenlabs/ConversationClientImpl.kt
+++ b/elevenlabs-sdk/src/main/java/io/elevenlabs/ConversationClientImpl.kt
@@ -146,12 +146,12 @@ class ConversationSessionBuilder(private val context: Context) {
     /**
      * Add a simple function-based tool
      */
-    fun addTool(name: String, function: suspend (Map<String, Any>) -> String): ConversationSessionBuilder {
+    fun addTool(name: String, function: suspend (Map<String, Any>) -> String?): ConversationSessionBuilder {
         customTools[name] = object : ClientTool {
-            override suspend fun execute(parameters: Map<String, Any>): ClientToolResult {
+            override suspend fun execute(parameters: Map<String, Any>): ClientToolResult? {
                 return try {
                     val result = function(parameters)
-                    ClientToolResult.success(result)
+                    result?.let { ClientToolResult.success(it) }
                 } catch (e: Exception) {
                     ClientToolResult.failure("Function execution failed: ${e.message}")
                 }

--- a/elevenlabs-sdk/src/main/java/io/elevenlabs/models/ConversationEvent.kt
+++ b/elevenlabs-sdk/src/main/java/io/elevenlabs/models/ConversationEvent.kt
@@ -73,7 +73,7 @@ sealed class ConversationEvent {
         val toolName: String,
         val parameters: Map<String, Any>,
         val toolCallId: String,
-        val expectsResponse: Boolean = true,
+        val expectsResponse: Boolean = false,
     ) : ConversationEvent()
 
     /**

--- a/elevenlabs-sdk/src/main/java/io/elevenlabs/network/ConversationEventParser.kt
+++ b/elevenlabs-sdk/src/main/java/io/elevenlabs/network/ConversationEventParser.kt
@@ -130,7 +130,7 @@ object ConversationEventParser {
             toolName = obj.get("tool_name")?.asString ?: "",
             parameters = parameters,
             toolCallId = obj.get("tool_call_id")?.asString ?: "",
-            expectsResponse = obj.get("expects_response")?.asBoolean ?: true,
+            expectsResponse = obj.get("expects_response")?.asBoolean == true,
         )
     }
 

--- a/example-app/src/main/java/io/elevenlabs/example/viewmodels/ConversationViewModel.kt
+++ b/example-app/src/main/java/io/elevenlabs/example/viewmodels/ConversationViewModel.kt
@@ -73,7 +73,7 @@ class ConversationViewModel(application: Application) : AndroidViewModel(applica
                     dynamicVariables = null,
                     clientTools = mapOf(
                         "logMessage" to object : io.elevenlabs.ClientTool {
-                            override suspend fun execute(parameters: Map<String, Any>): io.elevenlabs.ClientToolResult {
+                            override suspend fun execute(parameters: Map<String, Any>): io.elevenlabs.ClientToolResult? {
                                 val message = parameters["message"] as? String
                                     ?: return io.elevenlabs.ClientToolResult.failure("Missing 'message' parameter")
                                 val level = parameters["level"] as? String ?: "INFO"


### PR DESCRIPTION
## Summary
- Enable client tools to return `null` to suppress outbound tool results
- Parse `expects_response` as optional to avoid default acks
- Document fire-and-forget tools and update examples

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab277ea8f883309d60351941c501fe