### PR TITLE
Fix publishing configuration for release variant

### DIFF
--- a/elevenlabs-sdk/build.gradle.kts
+++ b/elevenlabs-sdk/build.gradle.kts
@@ -43,6 +43,7 @@ namespace = "io.elevenlabs"
     buildFeatures {
         buildConfig = true
     }
+
 }
 
 dependencies {
@@ -118,12 +119,14 @@ mavenPublishing {
 
 publishing {
     publications {
-        create<MavenPublication>("maven") {
+        register<MavenPublication>("release") {
             groupId = "com.github.franklintra"
             artifactId = "elevenlabs-sdk"
             version = "1.0"
 
-            from(components["release"])
+            afterEvaluate {
+                from(components["release"])
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- defer Maven publication until after evaluation so release component is available

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab392662a08330a46055194ad8119c