### PR TITLE
Make signing optional for JitPack builds

### DIFF
--- a/elevenlabs-sdk/build.gradle.kts
+++ b/elevenlabs-sdk/build.gradle.kts
@@ -79,8 +79,10 @@ mavenPublishing {
     // Enable publishing to Maven Central
     publishToMavenCentral(automaticRelease = true)
 
-    // Enable GPG signing (required for Maven Central)
-    signAllPublications()
+    // Only enable GPG signing when signing properties are provided
+    if (project.hasProperty("signing.keyId")) {
+        signAllPublications()
+    }
 
     // Configure coordinates (group:artifactId:version)
     coordinates("io.elevenlabs", "elevenlabs-android", project.version.toString())
@@ -115,6 +117,11 @@ mavenPublishing {
             developerConnection.set("scm:git:ssh://git@github.com/elevenlabs/elevenlabs-android.git")
         }
     }
+}
+
+// Skip signing tasks entirely if no signing configuration is supplied
+tasks.withType<org.gradle.plugins.signing.Sign>().configureEach {
+    onlyIf { project.hasProperty("signing.keyId") }
 }
 
 publishing {


### PR DESCRIPTION
## Summary
- Skip signing tasks when no signing configuration is supplied
- Allow JitPack to build the library without GPG keys

## Testing
- `./gradlew build publishToMavenLocal` *(fails: SDK location not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68ab3e1f81848330ad3888a76ad1a8f5